### PR TITLE
fix(health): remove token validity from health/ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ make devkit
 - Data is encrypted with AES-256 using keys derived from your seeds
 - Supports automatic TLS certificate reloading for Kubernetes deployments
 
+### Health Checks
+
+The proxy provides Kubernetes-compatible health endpoints:
+
+- `/health/live` - Liveness probe
+- `/health/ready` - Readiness probe
+
 ## License
 
 MIT

--- a/health/config.go
+++ b/health/config.go
@@ -2,11 +2,6 @@ package health
 
 // Config holds health check configuration options.
 type Config struct {
-	// StrictReadiness determines if degraded status should fail readiness checks
-	// When true: degraded = 503 (Kubernetes-friendly, removes from load balancer)
-	// When false: degraded = 200 (allows degraded pods to receive traffic)
-	StrictReadiness bool
-
 	// Version to include in health responses
 	Version string
 }
@@ -14,7 +9,6 @@ type Config struct {
 // DefaultConfig returns health check configuration with sensible defaults.
 func DefaultConfig() *Config {
 	return &Config{
-		StrictReadiness: true, // Default to Kubernetes-friendly behavior
-		Version:         "schwab-proxy-1.0.0",
+		Version: "schwab-proxy-1.0.0",
 	}
 }

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -166,54 +166,6 @@ func TestHTTPHandler_Readiness(t *testing.T) {
 	}
 }
 
-func TestHTTPHandler_ReadinessStrictMode(t *testing.T) {
-	t.Parallel()
-	// Test strict mode (default) - degraded should return 503
-	config := health.DefaultConfig()
-	config.StrictReadiness = true
-	config.Version = testVersion
-
-	checker := health.NewManagerWithConfig(config)
-	handler := health.NewHTTPHandler(checker)
-
-	// Add a degraded checker
-	degradedChecker := &DegradedChecker{}
-	checker.AddChecker(degradedChecker)
-
-	req := httptest.NewRequest(http.MethodGet, "/health/ready", nil)
-	recorder := httptest.NewRecorder()
-
-	handler.ReadinessHandler(recorder, req)
-
-	if recorder.Code != http.StatusServiceUnavailable {
-		t.Errorf("Expected status 503 in strict mode for degraded, got %d", recorder.Code)
-	}
-}
-
-func TestHTTPHandler_ReadinessPermissiveMode(t *testing.T) {
-	t.Parallel()
-	// Test permissive mode - degraded should return 200
-	config := health.DefaultConfig()
-	config.StrictReadiness = false
-	config.Version = testVersion
-
-	checker := health.NewManagerWithConfig(config)
-	handler := health.NewHTTPHandler(checker)
-
-	// Add a degraded checker
-	degradedChecker := &DegradedChecker{}
-	checker.AddChecker(degradedChecker)
-
-	req := httptest.NewRequest(http.MethodGet, "/health/ready", nil)
-	recorder := httptest.NewRecorder()
-
-	handler.ReadinessHandler(recorder, req)
-
-	if recorder.Code != http.StatusOK {
-		t.Errorf("Expected status 200 in permissive mode for degraded, got %d", recorder.Code)
-	}
-}
-
 // DegradedChecker always returns degraded status for testing.
 type DegradedChecker struct{}
 


### PR DESCRIPTION
Including the token validity and existence in the readiness checks prevents k8s from sending traffic to the pod, which prevents either token refresh from happening automatically on requests or initial setup since the ingress will not send traffic.