### PR TITLE
fix(proxy): preserve headers

### DIFF
--- a/api/schwab.go
+++ b/api/schwab.go
@@ -263,7 +263,7 @@ func (c *SchwabClient) Call(
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	c.setDefaultHeaders(req, accessToken, method)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
 	c.copyHeaders(req, headers)
 
 	resp, err := c.httpClient.Do(req)
@@ -301,20 +301,6 @@ func (c *SchwabClient) buildRequestURL(endpoint string) string {
 	return requestURL + endpoint
 }
 
-// setDefaultHeaders sets required headers for Schwab API requests.
-func (c *SchwabClient) setDefaultHeaders(req *http.Request, accessToken, method string) {
-	// Add authorization header - always use "Bearer" for Schwab API
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-
-	// Add required headers
-	req.Header.Set("Accept", "application/json")
-
-	// Add content type if not present
-	if req.Header.Get("Content-Type") == "" && method != "GET" && method != "DELETE" {
-		req.Header.Set("Content-Type", "application/json")
-	}
-}
-
 // copyHeaders copies headers from original request, skipping certain headers.
 func (c *SchwabClient) copyHeaders(req *http.Request, headers http.Header) {
 	for key, values := range headers {
@@ -323,8 +309,6 @@ func (c *SchwabClient) copyHeaders(req *http.Request, headers http.Header) {
 			continue
 		}
 
-		for _, value := range values {
-			req.Header.Add(key, value)
-		}
+		req.Header[key] = values
 	}
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -480,9 +480,7 @@ func (p *APIProxy) forwardRequest(writer http.ResponseWriter, request *http.Requ
 
 	// Copy response headers
 	for k, values := range resp.Header {
-		for _, v := range values {
-			writer.Header().Add(k, v)
-		}
+		writer.Header()[k] = values
 	}
 
 	// Set the status code

--- a/python/schwab_monkeypatch.py
+++ b/python/schwab_monkeypatch.py
@@ -67,7 +67,6 @@ def _patch_sync_client(sync_module, proxy_base_url: str):
         dest = proxy_base_url + path
         headers = {
             "Authorization": "Bearer " + str(self.token_metadata.token["access_token"]),
-            "Content-Type": "application/json",
         }
         # Use the session's internal httpx client which has our SSL settings
         return self.session.session.post(dest, json=data, headers=headers)
@@ -76,7 +75,6 @@ def _patch_sync_client(sync_module, proxy_base_url: str):
         dest = proxy_base_url + path
         headers = {
             "Authorization": "Bearer " + str(self.token_metadata.token["access_token"]),
-            "Content-Type": "application/json",
         }
         # Use the session's internal httpx client which has our SSL settings
         return self.session.session.put(dest, json=data, headers=headers)
@@ -112,7 +110,6 @@ def _patch_async_client(async_module, proxy_base_url: str):
         dest = proxy_base_url + path
         headers = {
             "Authorization": "Bearer " + str(self.token_metadata.token["access_token"]),
-            "Content-Type": "application/json",
         }
         # Use the session's internal httpx client which has our SSL settings
         return await self.session.session.post(dest, json=data, headers=headers)
@@ -121,7 +118,6 @@ def _patch_async_client(async_module, proxy_base_url: str):
         dest = proxy_base_url + path
         headers = {
             "Authorization": "Bearer " + str(self.token_metadata.token["access_token"]),
-            "Content-Type": "application/json",
         }
         # Use the session's internal httpx client which has our SSL settings
         return await self.session.session.put(dest, json=data, headers=headers)


### PR DESCRIPTION
The proxy would inject its own headers, but this would cause duplicate headers. Instead we should copy all the headers as is and only override the host and auth headers.