### PR TITLE
fix(auth): accept basic auth on token endpoint

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -54,7 +54,10 @@ version-resolver:
 autolabeler:
   - label: "automation"
     title:
-      - "/^(build|ci|perf|refactor|test).*/i"
+      - "/^(build|ci).*/i"
+  - label: "performance"
+    title:
+      - "/^(perf).*/i"
   - label: "enhancement"
     title:
       - "/^(style).*/i"
@@ -72,7 +75,7 @@ autolabeler:
       - "/^(infrastructure).*/i"
   - label: "maintenance"
     title:
-      - "/^(chore|maintenance).*/i"
+      - "/^(chore|maintenance|refactor|test).*/i"
   - label: "revert"
     title:
       - "/^(revert).*/i"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,9 +12,9 @@
   customManagers: [
     {
       customType: 'regex',
-      description: 'Update Alpine APK packages in Dockerfile.devkit',
+      description: 'Update Alpine APK packages in Containerfile.devkit',
       managerFilePatterns: [
-        '/Dockerfile\\.devkit$/',
+        '/Containerfile\\.devkit$/',
       ],
       matchStrings: [
         '#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\nARG .*?="(?<currentValue>.*)"',

--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -14,7 +14,6 @@ name: Auto Labeler
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 jobs:
   main:
@@ -24,9 +23,8 @@ jobs:
 
     steps:
       # yamllint disable-line rule:line-length rule:comments
-      - uses: release-drafter/release-drafter@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0
+      - uses: release-drafter/release-drafter/autolabeler@44a942e465867c7465b76aa808ddca6e0acae5da # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           config-name: release-drafter.yaml
-          disable-releaser: true

--- a/Containerfile.devkit
+++ b/Containerfile.devkit
@@ -1,5 +1,5 @@
-# Get as many dependancies from official docker images to allow
-# `dependabot` to manage them for us.
+# Get as many dependencies from official container images as possible so
+# Renovate can keep them current for us.
 FROM docker.io/golangci/golangci-lint:v2.11.3@sha256:e838e8ab68aaefe83e2408691510867ade9329c0e0b895a3fb35eb93d1c2a4ba as golangci-lint
 FROM ghcr.io/hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e as hadolint
 FROM docker.io/golang:1.26.1-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039
@@ -12,14 +12,17 @@ ARG GCC_VERSION="15.2.0-r2"
 ARG GIT_VERSION="2.52.0-r0"
 # renovate: datasource=repology depName=alpine_3_23/make versioning=loose
 ARG MAKE_VERSION="4.4.1-r3"
+# renovate: datasource=repology depName=alpine_3_23/musl versioning=loose
+ARG MUSL_VERSION="1.2.5-r23"
 # renovate: datasource=repology depName=alpine_3_23/musl-dev versioning=loose
-ARG MUSL_DEV_VERSION="1.2.5-r21"
+ARG MUSL_DEV_VERSION="1.2.5-r23"
 
 RUN apk add --no-cache \
     bash="${BASH_VERSION}" \
     gcc="${GCC_VERSION}" \
     git="${GIT_VERSION}" \
     make="${MAKE_VERSION}" \
+    musl="${MUSL_VERSION}" \
     musl-dev="${MUSL_DEV_VERSION}"
 
 COPY --from=hadolint /bin/hadolint /usr/local/bin/

--- a/auth/client.go
+++ b/auth/client.go
@@ -150,11 +150,6 @@ func (c *Client) GetAudience() fosite.Arguments {
 	return c.Audience
 }
 
-// GetTokenEndpointAuthMethod returns the client's token endpoint authentication method.
-func (c *Client) GetTokenEndpointAuthMethod() string {
-	return "client_secret_post" // Allow client secret in POST body
-}
-
 // GenerateRandomString creates a random string of the specified length.
 func GenerateRandomString(length int) (string, error) {
 	bytes := make([]byte, length)

--- a/auth/server.go
+++ b/auth/server.go
@@ -47,7 +47,7 @@ type Server struct {
 }
 
 // NewServer creates a new OAuth2 server using Fosite.
-func NewServer(store StorageInterface, cfg *config.Config, jwtSigningKey []byte) (*Server, error) {
+func NewServer(ctx context.Context, store StorageInterface, cfg *config.Config, jwtSigningKey []byte) (*Server, error) {
 	storage := &Storage{
 		storage: store,
 		cfg:     cfg,
@@ -59,10 +59,16 @@ func NewServer(store StorageInterface, cfg *config.Config, jwtSigningKey []byte)
 		RefreshTokenLifespan:       cfg.OAuth2RefreshTokenExpiry,
 		AuthorizeCodeLifespan:      cfg.OAuth2AuthCodeExpiry,
 		GlobalSecret:               jwtSigningKey,
+		ScopeStrategy:              fosite.WildcardScopeStrategy,
+		AudienceMatchingStrategy:   fosite.DefaultAudienceMatchingStrategy,
 		SendDebugMessagesToClients: cfg.SendDebugMessagesToClients,
 	}
 
 	// Create OAuth2 provider with both client credentials and authorization code flows
+	// Set mutable Fosite defaults explicitly before serving requests so concurrent
+	// OAuth requests do not race on lazy config initialization.
+	fositeConfig.GetSecretsHasher(ctx)
+
 	provider := compose.Compose(
 		fositeConfig,
 		storage,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -108,7 +108,7 @@ func NewAPIProxy(
 		return nil, err
 	}
 
-	server, err := auth.NewServer(storageAdapter, cfg, jwtSigningKey)
+	server, err := auth.NewServer(ctx, storageAdapter, cfg, jwtSigningKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OAuth2 server: %w", err)
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -3,6 +3,7 @@ package proxy_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -120,7 +121,7 @@ func createTestProxy(t *testing.T) (*proxy.APIProxy, func()) {
 
 	// Create proxy with nil OTel providers for testing
 	proxyInstance, err := proxy.NewAPIProxy(
-		context.Background(),
+		ctx,
 		cfg,
 		mockProvider,
 		tokenService,
@@ -191,6 +192,40 @@ func testCreateClient(t *testing.T, proxyInstance *proxy.APIProxy) {
 			t.Error("Expected secret to be returned")
 		}
 	})
+}
+
+func createOAuthClient(t *testing.T, proxyInstance *proxy.APIProxy) proxy.ClientWithSecretResponse {
+	t.Helper()
+
+	createReq := proxy.CreateClientRequest{
+		Name:        "OAuth Test Client",
+		Description: "Client for OAuth token auth tests",
+		RedirectURI: "http://localhost:3000/callback",
+		Scopes:      []string{"read"},
+	}
+
+	body, err := json.Marshal(createReq)
+	if err != nil {
+		t.Fatalf("failed to marshal create request: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/clients", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer test-admin-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	writer := httptest.NewRecorder()
+	proxyInstance.ServeHTTP(writer, req)
+
+	if writer.Code != http.StatusCreated {
+		t.Fatalf("expected create client status %d, got %d: %s", http.StatusCreated, writer.Code, writer.Body.String())
+	}
+
+	var response proxy.ClientWithSecretResponse
+	if err := json.NewDecoder(writer.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode create client response: %v", err)
+	}
+
+	return response
 }
 
 func testListClients(t *testing.T, proxyInstance *proxy.APIProxy) {
@@ -309,6 +344,60 @@ func TestFositeOAuth2(t *testing.T) {
 		}
 
 		t.Logf("OAuth2 endpoint response: %d - %s", writer.Code, writer.Body.String())
+	})
+
+	t.Run("TokenEndpointAcceptsHTTPBasicAuth", func(t *testing.T) {
+		t.Parallel()
+
+		client := createOAuthClient(t, proxyInstance)
+		data := url.Values{}
+		data.Set("grant_type", "refresh_token")
+		data.Set("refresh_token", "dummy-refresh-token")
+
+		req := httptest.NewRequestWithContext(
+			t.Context(),
+			http.MethodPost,
+			"/v1/oauth/token",
+			strings.NewReader(data.Encode()),
+		)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set(
+			"Authorization",
+			"Basic "+base64.StdEncoding.EncodeToString([]byte(client.ID+":"+client.Secret)),
+		)
+
+		writer := httptest.NewRecorder()
+		proxyInstance.ServeHTTP(writer, req)
+
+		if strings.Contains(writer.Body.String(), `"invalid_client"`) {
+			t.Fatalf("expected HTTP Basic client auth to be accepted, got invalid_client: %s", writer.Body.String())
+		}
+	})
+
+	t.Run("TokenEndpointStillAcceptsPostBodyAuth", func(t *testing.T) {
+		t.Parallel()
+
+		client := createOAuthClient(t, proxyInstance)
+		data := url.Values{}
+		data.Set("grant_type", "refresh_token")
+		data.Set("refresh_token", "dummy-refresh-token")
+		data.Set("client_id", client.ID)
+		data.Set("client_secret", client.Secret)
+
+		req := httptest.NewRequestWithContext(
+			t.Context(),
+			http.MethodPost,
+			"/v1/oauth/token",
+			strings.NewReader(data.Encode()),
+		)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		writer := httptest.NewRecorder()
+		proxyInstance.ServeHTTP(writer, req)
+
+		if strings.Contains(writer.Body.String(), `"invalid_client"`) {
+			t.Fatalf("expected POST-body client auth to remain accepted, got invalid_client: %s", writer.Body.String())
+		}
 	})
 
 	// Test that authorization endpoint is available (for authorization code flow)

--- a/streaming/proxy_test.go
+++ b/streaming/proxy_test.go
@@ -26,7 +26,9 @@ func TestProxy(t *testing.T) {
 		OAuth2AuthCodeExpiry:     10 * time.Minute,
 	}
 
-	authServer, err := auth.NewServer(mockStore, testConfig, signingKey)
+	ctx := t.Context()
+
+	authServer, err := auth.NewServer(ctx, mockStore, testConfig, signingKey)
 	if err != nil {
 		t.Fatalf("Failed to create auth server: %v", err)
 	}
@@ -45,8 +47,6 @@ func TestProxy(t *testing.T) {
 	proxy := streaming.NewProxy(tokenManager, authServer, metadataFunc)
 
 	// Test Start
-	ctx := context.Background()
-
 	err = proxy.Start(ctx)
 	if err != nil {
 		t.Fatalf("Start failed: %v", err)


### PR DESCRIPTION
The proxy client currently advertises client_secret_post as its token endpoint auth method.

That forces Fosite to reject HTTP Basic client authentication, even though its default OAuth client handling can accept either Basic auth or form-body credentials. This makes the token endpoint less compatible than it needs to be.

Drop the fixed token endpoint auth method from the client type so Fosite falls back to its standard client authentication flow.

Add regression coverage for both token auth styles to make sure HTTP Basic auth works and existing POST-body authentication keeps working.