### PR TITLE
fix(metrics): handle disabled metrics safely

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 )
 
 // contextKey is a custom type for context keys to avoid collisions.
@@ -22,7 +23,10 @@ const (
 
 var (
 	// defaultMeter is the fallback meter when none is found in context.
-	defaultMeter metric.Meter //nolint:gochecknoglobals // Thread-safe: protected by sync.Once
+	//nolint:gochecknoglobals // Safe no-op fallback when metrics are disabled
+	defaultMeter = metricnoop.NewMeterProvider().Meter(
+		"noop",
+	)
 
 	// meterOnce ensures we only initialize the default meter once.
 	meterOnce sync.Once //nolint:gochecknoglobals // Thread-safe: sync.Once is inherently safe

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -51,6 +51,21 @@ func TestFromContextFallback(t *testing.T) {
 	}
 }
 
+func TestMetricsWithoutInitialization(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	meter := metrics.FromContext(ctx)
+	if meter == nil {
+		t.Fatal("expected no-op meter when metrics are uninitialized")
+	}
+
+	metrics.RecordCounter(ctx, "uninitialized_counter", 1, "test", "true")
+	metrics.RecordHistogram(ctx, "uninitialized_histogram", 42, "test", "true")
+	metrics.RecordGauge(ctx, "uninitialized_gauge", 7, "test", "true")
+}
+
 func TestCounterFromContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The metrics helpers assumed `InitializeMeter` had already run, which caused startup to panic when `METRICS_ENABLED=false` and storage recorded metrics during boot. Default the package to a no-op meter and add regression coverage so metrics calls remain safe before observability initialization.